### PR TITLE
Refresh Thoughtworks-themed UI

### DIFF
--- a/infrastrucure.web/Views/Components/Index.cshtml
+++ b/infrastrucure.web/Views/Components/Index.cshtml
@@ -6,8 +6,9 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
     <h1 class="h3 mb-0">Components</h1>
-    <a class="btn btn-primary" asp-action="Create">
-        <i class="bi bi-plus-lg me-2" aria-hidden="true"></i>New Component
+    <a class="btn btn-accent d-inline-flex align-items-center" asp-action="Create">
+        <i class="fa-solid fa-plus me-2" aria-hidden="true"></i>
+        <span>New Component</span>
     </a>
 </div>
 
@@ -42,28 +43,33 @@
             }
         </select>
     </div>
-    <div class="col-12 col-sm-6 col-lg-3 d-flex gap-2">
-        <button type="submit" class="btn btn-outline-primary flex-grow-1 flex-sm-grow-0">
-            <i class="bi bi-funnel me-2" aria-hidden="true"></i>Apply Filters
-        </button>
-        <a class="btn btn-outline-secondary" asp-action="Index" asp-route-pageSize="@Model.PageSize">
-            <i class="bi bi-arrow-counterclockwise me-2" aria-hidden="true"></i>Reset
-        </a>
+    <div class="col-12 col-sm-6 col-lg-3">
+        <div class="d-flex flex-wrap">
+            <button type="submit" class="btn btn-accent flex-grow-1 flex-sm-grow-0" aria-label="Apply filters">
+                <i class="fa-solid fa-filter me-2" aria-hidden="true"></i>
+                <span>Filter</span>
+            </button>
+            <a class="btn btn-outline-primary flex-grow-1 flex-sm-grow-0" asp-action="Index" asp-route-pageSize="@Model.PageSize" aria-label="Reset filters">
+                <i class="fa-solid fa-rotate-left me-2" aria-hidden="true"></i>
+                <span>Reset</span>
+            </a>
+        </div>
     </div>
 </form>
 
 @if (!Model.HasResults)
 {
     <div class="card border-0 shadow-sm">
-        <div class="card-body py-5 text-center">
-            <div class="mb-3">
-                <i class="bi bi-hdd-network fs-1 text-primary" aria-hidden="true"></i>
+        <div class="card-body">
+            <div class="text-center py-5">
+                <i class="fa-solid fa-cubes fa-2xl mb-3" aria-hidden="true"></i>
+                <h5>No components found</h5>
+                <p class="text-muted">Try adjusting filters or create a new component.</p>
+                <a class="btn btn-accent" asp-action="Create">
+                    <i class="fa-solid fa-plus me-2" aria-hidden="true"></i>
+                    <span>New Component</span>
+                </a>
             </div>
-            <h2 class="h4 mb-2">No components found</h2>
-            <p class="text-secondary mb-4">Try adjusting filters or create a new component.</p>
-            <a class="btn btn-primary" asp-action="Create">
-                <i class="bi bi-plus-lg me-2" aria-hidden="true"></i>New Component
-            </a>
         </div>
     </div>
 }

--- a/infrastrucure.web/Views/Shared/_ActionButtons.cshtml
+++ b/infrastrucure.web/Views/Shared/_ActionButtons.cshtml
@@ -15,10 +15,10 @@
     var canTeardown = !ShouldDisable(isDeleted || isDeploying, !Model.CanTeardown);
     var canDelete = !ShouldDisable(isDeploying, !Model.CanDelete);
 
-    var deployButtonClasses = $"btn btn-sm btn-outline-primary btn-icon{(isDeploying ? " loading" : string.Empty)}";
+    var deployButtonClasses = $"btn btn-accent btn-icon btn-sm{(isDeploying ? " loading" : string.Empty)}";
 }
 <div class="btn-group" role="group" aria-label="@ariaLabel" data-component-action-group>
-    <a class="btn btn-sm btn-outline-secondary btn-icon"
+    <a class="btn btn-sm btn-outline-primary btn-icon"
        asp-controller="Components"
        asp-action="Edit"
        asp-route-id="@Model.Id"
@@ -26,7 +26,7 @@
        data-bs-toggle="tooltip"
        data-bs-placement="top"
        title="Edit">
-        <i class="bi bi-pencil" aria-hidden="true"></i>
+        <i class="fa-solid fa-pen" aria-hidden="true"></i>
         <span class="visually-hidden">Edit</span>
     </a>
     <form asp-controller="Components"
@@ -36,14 +36,14 @@
           class="d-inline">
         @Html.AntiForgeryToken()
         <button type="submit"
-                class="btn btn-sm btn-outline-success btn-icon"
+                class="btn btn-accent btn-icon btn-sm"
                 data-action="provision"
                 data-bs-toggle="tooltip"
                 data-bs-placement="top"
                 title="Provision"
                 aria-label="Provision component"
                 @(canProvision ? null : "disabled")>
-            <i class="bi bi-lightning-charge" aria-hidden="true"></i>
+            <i class="fa-solid fa-bolt" aria-hidden="true"></i>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
             <span class="visually-hidden">Provision</span>
         </button>
@@ -62,7 +62,7 @@
                 title="Deploy"
                 aria-label="Deploy component"
                 @(canDeploy ? null : "disabled")>
-            <i class="bi bi-rocket" aria-hidden="true"></i>
+            <i class="fa-solid fa-rocket" aria-hidden="true"></i>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
             <span class="visually-hidden">Deploy</span>
         </button>
@@ -74,20 +74,20 @@
           class="d-inline">
         @Html.AntiForgeryToken()
         <button type="submit"
-                class="btn btn-sm btn-outline-warning btn-icon"
+                class="btn btn-sm btn-outline-primary btn-icon"
                 data-action="teardown"
                 data-bs-toggle="tooltip"
                 data-bs-placement="top"
                 title="Teardown"
                 aria-label="Teardown component"
                 @(canTeardown ? null : "disabled")>
-            <i class="bi bi-plug-fill" aria-hidden="true"></i>
+            <i class="fa-solid fa-plug-circle-xmark" aria-hidden="true"></i>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
             <span class="visually-hidden">Teardown</span>
         </button>
     </form>
     <button type="button"
-            class="btn btn-sm btn-outline-danger btn-icon"
+            class="btn btn-sm btn-outline-primary btn-icon text-danger border-danger"
             data-action="delete"
             data-bs-toggle="tooltip"
             data-bs-placement="top"
@@ -97,7 +97,7 @@
             data-component-id="@Model.Id"
             data-component-name="@Model.Name"
             @(canDelete ? null : "disabled")>
-        <i class="bi bi-trash" aria-hidden="true"></i>
+        <i class="fa-solid fa-trash" aria-hidden="true"></i>
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
         <span class="visually-hidden">Delete</span>
     </button>

--- a/infrastrucure.web/Views/Shared/_ConfirmDeleteModal.cshtml
+++ b/infrastrucure.web/Views/Shared/_ConfirmDeleteModal.cshtml
@@ -7,16 +7,16 @@
             </div>
             <div class="modal-body">
                 <p class="mb-1">Are you sure you want to permanently delete <span class="fw-semibold" data-component-name>this component</span>?</p>
-                <p class="text-secondary mb-0">This action cannot be undone.</p>
+                <p class="text-muted mb-0">This action cannot be undone.</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Cancel</button>
                 <form asp-controller="Components" asp-action="Delete" method="post" class="d-inline" id="confirmDeleteForm">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="id" id="confirmDeleteId" />
-                    <button type="submit" class="btn btn-danger d-inline-flex align-items-center" data-confirm-delete-submit>
+                    <button type="submit" class="btn btn-accent d-inline-flex align-items-center" data-confirm-delete-submit>
                         <span class="spinner-border spinner-border-sm me-2 d-none" role="status" aria-hidden="true"></span>
-                        <i class="bi bi-trash me-2" aria-hidden="true"></i>
+                        <i class="fa-solid fa-trash me-2" aria-hidden="true" data-icon></i>
                         <span>Delete</span>
                     </button>
                 </form>

--- a/infrastrucure.web/Views/Shared/_EnvBadge.cshtml
+++ b/infrastrucure.web/Views/Shared/_EnvBadge.cshtml
@@ -2,13 +2,13 @@
 @{
     var value = (Model ?? string.Empty).Trim();
     var key = value.ToUpperInvariant();
-    var (label, bootstrapClass, modifierClass) = key switch
+    var (label, modifierClass) = key switch
     {
-        "DEV" => ("DEV", "bg-info text-dark", "status-dev"),
-        "QA" => ("QA", "bg-primary text-white", "status-qa"),
-        "PROD" => ("PROD", "bg-success", "status-prod"),
-        _ when string.IsNullOrWhiteSpace(value) => ("UNKNOWN", "bg-secondary", string.Empty),
-        _ => (key, "bg-secondary", string.Empty)
+        "DEV" => ("DEV", "badge-env-dev"),
+        "QA" => ("QA", "badge-env-qa"),
+        "PROD" => ("PROD", "badge-env-prod"),
+        _ when string.IsNullOrWhiteSpace(value) => ("UNKNOWN", "badge-env-unknown"),
+        _ => (key, "badge-env-unknown")
     };
 }
-<span class="badge status-badge @modifierClass @bootstrapClass" data-environment="@key">@label</span>
+<span class="badge @modifierClass" data-environment="@key">@label</span>

--- a/infrastrucure.web/Views/Shared/_Layout.cshtml
+++ b/infrastrucure.web/Views/Shared/_Layout.cshtml
@@ -5,12 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Infrastructure Deployer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+          integrity="sha512-M9z1FJFDaRao7IhiHBpjz2uVH54camzatoNgtr1cGukdxbYlR5c+3F4iAfDdc0AGJi/5luWGINuDhcE/UZ5PQw=="
+          crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="~/css/styles.css" asp-append-version="true" />
+    <meta name="theme-color" content="#0E4B5A" />
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm py-2">
+        <nav class="navbar navbar-expand-lg navbar-light brand-bar py-2">
             <div class="container-fluid">
                 <a class="navbar-brand d-flex align-items-center" asp-controller="Components" asp-action="Index">
                     <img src="~/images/logo.svg"

--- a/infrastrucure.web/Views/Shared/_StatusBadge.cshtml
+++ b/infrastrucure.web/Views/Shared/_StatusBadge.cshtml
@@ -2,14 +2,14 @@
 @{
     var value = (Model ?? string.Empty).Trim();
     var key = value.ToUpperInvariant();
-    var (label, bootstrapClass, modifierClass) = key switch
+    var (label, modifierClass) = key switch
     {
-        "PROVISIONED" => ("Provisioned", "bg-success", "status-provisioned"),
-        "DEPLOYING" => ("Deploying", "bg-warning text-dark", "status-deploying"),
-        "FAILED" => ("Failed", "bg-danger", "status-failed"),
-        "DELETED" => ("Deleted", "bg-secondary", "status-deleted"),
-        _ when string.IsNullOrWhiteSpace(value) => ("Unknown", "bg-secondary", string.Empty),
-        _ => (System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value.ToLowerInvariant()), "bg-primary", string.Empty)
+        "PROVISIONED" => ("Provisioned", "badge-status-provisioned"),
+        "DEPLOYING" => ("Deploying", "badge-status-deploying"),
+        "FAILED" => ("Failed", "badge-status-failed"),
+        "DELETED" => ("Deleted", "badge-status-deleted"),
+        _ when string.IsNullOrWhiteSpace(value) => ("Unknown", "badge-status-deleted"),
+        _ => (System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value.ToLowerInvariant()), "badge-status-deploying")
     };
 }
-<span class="badge status-badge @modifierClass @bootstrapClass" data-status="@key">@label</span>
+<span class="badge @modifierClass" data-status="@key">@label</span>

--- a/infrastrucure.web/Views/Shared/_Toasts.cshtml
+++ b/infrastrucure.web/Views/Shared/_Toasts.cshtml
@@ -31,26 +31,24 @@
         @foreach (var toast in toasts)
         {
             var role = string.Equals(toast.Variant, "danger", System.StringComparison.OrdinalIgnoreCase) ? "alert" : "status";
-            var icon = toast.Variant switch
+            var (toastClass, iconClass) = toast.Variant.ToLowerInvariant() switch
             {
-                "success" => "check-circle-fill",
-                "warning" => "exclamation-triangle-fill",
-                _ => "exclamation-octagon-fill"
+                "success" => ("brand-success", "fa-circle-check"),
+                "warning" => ("brand-warning", "fa-triangle-exclamation"),
+                _ => ("brand-error", "fa-triangle-exclamation")
             };
-            <div class="toast align-items-center text-bg-@toast.Variant shadow-sm mb-2" role="@role" data-bs-autohide="true" data-bs-delay="6000">
-                <div class="d-flex">
-                    <div class="toast-body d-flex">
-                        <i class="bi bi-@icon me-3 fs-4" aria-hidden="true"></i>
-                        <div>
-                            <div class="fw-semibold">@toast.Title</div>
-                            <div>@toast.Message</div>
-                            @if (!string.IsNullOrWhiteSpace(toast.Detail))
-                            {
-                                <div class="small opacity-75">@toast.Detail</div>
-                            }
-                        </div>
-                    </div>
-                    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            <div class="toast shadow-sm mb-2 @toastClass" role="@role" data-bs-autohide="true" data-bs-delay="6000">
+                <div class="toast-header">
+                    <i class="fa-solid @iconClass me-2" aria-hidden="true"></i>
+                    <strong class="me-auto">@toast.Title</strong>
+                    <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+                </div>
+                <div class="toast-body">
+                    <div>@toast.Message</div>
+                    @if (!string.IsNullOrWhiteSpace(toast.Detail))
+                    {
+                        <div class="small text-muted mt-1">@toast.Detail</div>
+                    }
                 </div>
             </div>
         }

--- a/infrastrucure.web/wwwroot/css/styles.css
+++ b/infrastrucure.web/wwwroot/css/styles.css
@@ -1,45 +1,120 @@
-/* Navbar look & feel */
-.navbar {
-    --bs-navbar-padding-y: .5rem;
+:root {
+  /* Brand tokens (adjust if you want closer match) */
+  --tw-primary: #0E4B5A;
+  --tw-primary-700: #0A3944;
+  --tw-accent: #FF4F79;
+  --tw-ink: #102226;
+  --tw-bg: #F6F8F9;
+  --tw-surface: #FFFFFF;
+  --tw-outline: #DCE3E7;
+
+  /* Semantic */
+  --tw-success: #2E7D32;
+  --tw-warning: #F6A723;
+  --tw-danger: #D7263D;
+  --tw-info: #0EA5E9;
+
+  /* Map to Bootstrap */
+  --bs-primary: var(--tw-primary);
+  --bs-secondary: var(--tw-ink);
+  --bs-success: var(--tw-success);
+  --bs-warning: var(--tw-warning);
+  --bs-danger: var(--tw-danger);
+  --bs-info: var(--tw-info);
+  --bs-body-bg: var(--tw-bg);
+  --bs-body-color: var(--tw-ink);
+  --bs-link-color: var(--tw-primary);
+  --bs-link-hover-color: var(--tw-primary-700);
+  --bs-border-color: var(--tw-outline);
 }
 
-.navbar-brand {
-    font-weight: 700;
-    letter-spacing: .2px;
+body {
+  background: var(--tw-bg);
+  color: var(--tw-ink);
+  font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
 }
 
-/* Bigger logo, scales up on large screens */
+header {
+  box-shadow: 0 2px 14px rgba(16, 34, 38, 0.06);
+}
+
+.navbar.brand-bar {
+  background: var(--tw-surface);
+  border-bottom: 1px solid var(--tw-outline);
+}
+
+.navbar .navbar-brand {
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: var(--tw-primary);
+}
+
+.navbar .navbar-brand:hover,
+.navbar .navbar-brand:focus-visible {
+  color: var(--tw-primary-700);
+}
+
 .brand-logo {
-    height: auto;
-    width: auto;
-    display: block;
+  height: 48px;
+  width: auto;
+  display: block;
+  object-fit: contain;
 }
 
 @media (min-width: 992px) {
-    .brand-logo {
-        height: 44px;
-    }
+  .brand-logo {
+    height: 56px;
+  }
 }
 
-/* Keep brand text readable but not oversized */
 .brand-text {
-    font-size: 1.125rem;
-    line-height: 1;
+  font-size: 1.125rem;
+  color: var(--tw-primary);
+}
+
+.navbar-nav .nav-link {
+  font-weight: 600;
+  color: var(--tw-ink);
+}
+
+.navbar-nav .nav-link:focus-visible,
+.navbar-nav .nav-link:hover {
+  color: var(--tw-primary);
+}
+
+.btn-accent {
+  --bs-btn-bg: var(--tw-accent);
+  --bs-btn-border-color: var(--tw-accent);
+  --bs-btn-hover-bg: #ff6a90;
+  --bs-btn-hover-border-color: #ff6a90;
+  --bs-btn-active-bg: #e63d68;
+  --bs-btn-active-border-color: #e63d68;
+  --bs-btn-color: #ffffff;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-focus-shadow-rgb: 255, 79, 121;
 }
 
 .btn-icon {
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 36px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.5rem;
   position: relative;
+  border-radius: 0.75rem;
   line-height: 1;
+  gap: 0.25rem;
 }
 
-.btn-icon .bi {
-  font-size: 1rem;
+.btn-icon.btn-sm {
+  width: 34px;
+  height: 34px;
+}
+
+.btn-icon .fa {
+  font-size: 0.875rem;
 }
 
 .btn-icon .spinner-border {
@@ -51,9 +126,10 @@
 
 .btn-icon.loading {
   pointer-events: none;
+  opacity: 0.75;
 }
 
-.btn-icon.loading .bi {
+.btn-icon.loading .fa {
   opacity: 0;
 }
 
@@ -62,76 +138,153 @@
   position: absolute;
 }
 
-.btn-icon:focus-visible {
-  outline: 2px solid var(--bs-primary);
+a {
+  color: var(--tw-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--tw-primary-700);
+  text-decoration: underline;
+}
+
+:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tw-accent) 50%, transparent);
   outline-offset: 2px;
 }
 
-.btn-icon.btn-outline-success:focus-visible {
-  outline-color: var(--bs-success);
+.card,
+.table,
+.modal-content {
+  background: var(--tw-surface);
 }
 
-.btn-icon.btn-outline-warning:focus-visible {
-  outline-color: var(--bs-warning);
-}
-
-.btn-icon.btn-outline-danger:focus-visible {
-  outline-color: var(--bs-danger);
-}
-
-.btn-icon.btn-outline-secondary:focus-visible {
-  outline-color: var(--bs-secondary);
-}
-
-.btn-icon.btn-outline-primary:focus-visible {
-  outline-color: var(--bs-primary);
-}
-
-.status-badge {
+.badge {
+  font-weight: 600;
+  letter-spacing: 0.02em;
   border-radius: 999px;
   padding: 0.25rem 0.75rem;
-  font-size: 0.75rem;
+}
+
+.badge-env-dev {
+  background: #d6f4ea;
+  color: var(--tw-primary);
+}
+
+.badge-env-qa {
+  background: #e7f0ff;
+  color: var(--tw-primary);
+}
+
+.badge-env-prod {
+  background: #ffe6ef;
+  color: #7a1033;
+}
+
+.badge-env-unknown {
+  background: #e4eaee;
+  color: var(--tw-ink);
+}
+
+.badge-status-provisioned {
+  background: var(--tw-success);
+  color: #ffffff;
+}
+
+.badge-status-deploying {
+  background: var(--tw-warning);
+  color: #1b1b1b;
+}
+
+.badge-status-failed {
+  background: var(--tw-danger);
+  color: #ffffff;
+}
+
+.badge-status-deleted {
+  background: #b0b8bd;
+  color: #ffffff;
+}
+
+.table thead th {
+  background: #eef3f6;
+  border-bottom: 1px solid var(--tw-outline);
+  color: var(--tw-ink);
   font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
 }
 
-.status-badge.status-dev {
-  background-color: #e0f2ff;
-  color: #0a3b78;
+.table-hover tbody tr:hover {
+  background: #f4f8fb;
 }
 
-.status-badge.status-qa {
-  background-color: #fff4d6;
-  color: #664d03;
+.table-striped > tbody > tr:nth-of-type(odd) > * {
+  box-shadow: inset 0 0 0 9999px rgba(14, 75, 90, 0.02);
 }
 
-.status-badge.status-prod {
-  background-color: #d1e7dd;
-  color: #0f5132;
+.toast-container {
+  z-index: 1080;
 }
 
-.status-badge.status-provisioned {
-  background-color: #d1e7dd;
-  color: #0f5132;
+.toast.brand-success,
+.toast.brand-error,
+.toast.brand-warning {
+  border-left: 4px solid var(--tw-primary);
+  border-radius: 0.75rem;
+  background: var(--tw-surface);
+  color: var(--tw-ink);
 }
 
-.status-badge.status-deploying {
-  background-color: #fff4d6;
-  color: #664d03;
+.toast.brand-error {
+  border-left-color: var(--tw-danger);
 }
 
-.status-badge.status-deleted {
-  background-color: #e2e3e5;
-  color: #41464b;
+.toast.brand-warning {
+  border-left-color: var(--tw-warning);
 }
 
-.status-badge.status-failed {
-  background-color: #f8d7da;
-  color: #842029;
+.toast .toast-header {
+  background: transparent;
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.toast .toast-body {
+  font-size: 0.95rem;
+}
+
+.toast .toast-header .fa-solid {
+  font-size: 1.125rem;
+  color: var(--tw-primary);
+}
+
+.toast.brand-error .toast-header .fa-solid {
+  color: var(--tw-danger);
+}
+
+.toast.brand-warning .toast-header .fa-solid {
+  color: var(--tw-warning);
+}
+
+.toast .btn-close {
+  filter: invert(20%);
+}
+
+.filters-row {
+  row-gap: 1rem;
+}
+
+.filters-row .form-label {
+  font-weight: 600;
+  color: var(--tw-ink);
+}
+
+.filters-row .btn-group,
+.filters-row .d-flex {
+  gap: 0.75rem;
+}
+
+.filters-row .btn {
+  font-weight: 600;
 }
 
 .table-responsive-sm {
@@ -144,21 +297,18 @@
   }
 }
 
-.filters-row {
-  row-gap: 1rem;
+.text-muted {
+  color: color-mix(in srgb, var(--tw-ink) 60%, #ffffff) !important;
 }
 
-.filters-row .form-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  margin-bottom: 0.35rem;
+.modal-header {
+  border-bottom: 1px solid var(--tw-outline);
 }
 
-.filters-row .form-select,
-.filters-row .form-control {
-  min-width: 0;
+.modal-footer {
+  border-top: 1px solid var(--tw-outline);
 }
 
-.toast-container {
-  z-index: 1080;
+[data-component-name] {
+  color: var(--tw-primary);
 }

--- a/infrastrucure.web/wwwroot/js/site.js
+++ b/infrastrucure.web/wwwroot/js/site.js
@@ -70,7 +70,7 @@
         const nameTarget = modalEl.querySelector('[data-component-name]');
         const submitButton = modalEl.querySelector('[data-confirm-delete-submit]');
         const spinner = submitButton ? submitButton.querySelector('.spinner-border') : null;
-        const icon = submitButton ? submitButton.querySelector('.bi') : null;
+        const icon = submitButton ? submitButton.querySelector('[data-icon]') : null;
 
         const resetButtonState = () => {
             if (submitButton) {


### PR DESCRIPTION
## Summary
- apply a Thoughtworks-inspired palette and Font Awesome icons across the shared layout and site styles
- restyle the components index filters, empty state, and action buttons to align with the refreshed theme
- polish toast notifications, status/environment badges, and the delete confirmation modal for accessible feedback

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc1f5d1458832691e1c1687f0b9fd1